### PR TITLE
Fix GAUSSBLUR1/2 strength param, correct MVTools `refine` documentation.

### DIFF
--- a/vsdenoise/mvtools.py
+++ b/vsdenoise/mvtools.py
@@ -769,7 +769,8 @@ class MVTools:
         :param tr:                  Temporal radius of the processing.
         :param refine:              This represents the times the analyzed clip will be recalculated.\n
                                     With every recalculation step, the block size will be further refined.\n
-                                    i.e. `refine=4` it will analyze at `block_size=32`, then refine at 16, 8, 4.
+                                    i.e. `refine=3` it will analyze at `block_size=32`, then refine at 16, 8, 4.
+                                    Set `refine=0` to disable recalculation completely.
         :param pel:                 Pixel EnLargement value, a.k.a. subpixel accuracy of the motion estimation.\n
                                     Value can only be 1, 2 or 4.
                                      * 1 means a precision to the pixel.

--- a/vsdenoise/prefilters.py
+++ b/vsdenoise/prefilters.py
@@ -164,7 +164,7 @@ class PrefilterBase(CustomIntEnum, metaclass=PrefilterMeta):
             if 'sharp' not in kwargs and 'sigma' not in kwargs:
                 kwargs |= dict(sigma=1.75)
 
-            strg = clamp(kwargs.pop('strenght', 50 if pref_type == Prefilter.GAUSSBLUR2 else 90), 0, 98) + 1
+            strg = clamp(kwargs.pop('strength', 50 if pref_type == Prefilter.GAUSSBLUR2 else 90), 0, 98) + 1
 
             gaussblur = gauss_blur(boxblur, **(kwargs | dict[str, Any](planes=planes)))
 


### PR DESCRIPTION
Refine is 1-based, not 0-based, so the example given only requires 3 refines.