### PR TITLE
Fix temporal_degrain to pass sad_mode and use REPAIR for post processing

### DIFF
--- a/vsdenoise/funcs.py
+++ b/vsdenoise/funcs.py
@@ -212,7 +212,7 @@ def temporal_degrain(
     thSCD = normalize_thscd(thSCD, ([192, 192, 192, 256, 320, 384][grain_level], 50), temporal_degrain, scale=False)
 
     if post is None:
-        post = PostProcess.DFTTEST
+        post = PostProcess.REPAIR
 
     postConf = post if isinstance(post, PostProcessConfig) else post()
 
@@ -266,7 +266,7 @@ def temporal_degrain(
         overlap=property(lambda self: self.block_size // 2), analyze_args=dict(chroma=chroma_motion),
         search=search_mode, super_args=dict(chroma=chroma_motion), planes=func.norm_planes, motion=MotionModeCustom(
             truemotion, motion_lambda, motion_ref.sad_limit, 50 if truemotion else 25, motion_ref.plevel, global_motion
-        )
+        ), sad_mode=sad_mode,
     )
 
     maxMV = MVTools(func.work_clip, **preset(tr=max(tr, postConf.tr), **kwargs)).analyze()


### PR DESCRIPTION

Finally got some free time, and after a lot of comparison with my original TemporalDegrain2 implementation, I nailed down the primary sources of differences between the two.

Essentially, sad_mode wasn't being passed in to the original MVTools preset like it used to, and the post processing denoiser was flipped to use (strong) DFTTest instead of the previous (much much lighter) Repair/RemoveGrain.

There's still some *very* small differences, but it seems to be due to some defaults buried deep down in the MVTools implementation, as well as a minor difference in the FFT3DFilter parameters.

But with this, the two outputs are pretty pretty darn close, and are good enough in my book.